### PR TITLE
hotfix: now semantic release adds the version to the pom

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -15,6 +15,12 @@
     "@semantic-release/release-notes-generator",
     "@semantic-release/changelog",
     [
+      "@semantic-release/exec",
+      {
+        "prepareCmd": "mvn versions:set -DnewVersion=${nextRelease.version} -DgenerateBackupPoms=false"
+      }
+    ],
+    [
       "@semantic-release/git",
       {
         "assets": ["CHANGELOG.md", "pom.xml"],


### PR DESCRIPTION
hotfix: semantic release wasn't adding the release tag to the pom file which caused some complications with the jenkins file